### PR TITLE
feat(youtube): added support for new endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,15 @@ npm install @supadata/js
 
 ```typescript
 import {
-  Supadata,
-  Transcript,
-  Scrape,
-  Map,
   Crawl,
   CrawlJob,
+  Map,
+  Scrape,
+  Supadata,
+  Transcript,
+  YoutubeChannel,
+  YoutubePlaylist,
+  YoutubeVideo,
 } from '@supadata/js';
 
 // Initialize the client
@@ -39,6 +42,31 @@ const transcript: Transcript = await supadata.youtube.transcript({
 const translated: Transcript = await supadata.youtube.translate({
   videoId: 'dQw4w9WgXcQ',
   lang: 'es',
+});
+
+// Get a YouTube Video metadata
+const video: YoutubeVideo = await supadata.youtube.video({
+  id: 'dQw4w9WgXcQ', // can be url or video id
+});
+
+// Get a YouTube channel metadata
+const channel: YoutubeChannel = await supadata.youtube.channel({
+  id: 'https://youtube.com/@RickAstleyVEVO', // can be url, channel id, handle
+});
+
+// Get a list of video IDs from a YouTube channel
+const channelVideos: string[] = await supadata.youtube.channel.videos({
+  id: 'https://youtube.com/@RickAstleyVEVO', // can be url, channel id, handle
+});
+
+// Get the metadata of a YouTube playlist
+const playlist: YoutubePlaylist = await supadata.youtube.playlist({
+  id: 'PLFgquLnL59alCl_2TQvOiD5Vgm1hCaGSI', // can be url or playlist id
+});
+
+// Get a list of video IDs from a YouTube playlist
+const playlistVideos: string[] = await supadata.youtube.playlist.videos({
+  id: 'https://www.youtube.com/playlist?list=PLlaN88a7y2_plecYoJxvRFTLHVbIVAOoc', // can be url or playlist id
 });
 
 // Scrape web content

--- a/example/index.ts
+++ b/example/index.ts
@@ -17,17 +17,52 @@ async function main() {
     });
     console.log('ℹ️ Transcript:', transcript);
 
-    // Example 2: Scrape web content
+    // Example 2: Get YouTube video info
+    console.log('\nℹ️ Getting YouTube video info...');
+    const videoInfo = await supadata.youtube.video({
+      id: 'dQw4w9WgXcQ', // Famous Rick Astley video as an example
+    });
+    console.log('ℹ️ Video info:', videoInfo);
+
+    // Example 3: Get YouTube channel info
+    console.log('\nℹ️ Getting YouTube channel info...');
+    const channelInfo = await supadata.youtube.channel({
+      id: 'https://www.youtube.com/@Fireship', // Fireship channel as an example
+    });
+    console.log('ℹ️ Channel info:', channelInfo);
+
+    // Example 4: Get YouTube channel videos
+    console.log('\nℹ️ Getting YouTube channel videos...');
+    const channelVideos = await supadata.youtube.channel.videos({
+      id: 'https://www.youtube.com/@Fireship', // Fireship channel as an example
+    });
+    console.log('ℹ️ Channel videos:', channelVideos);
+
+    // Example 5: Get YouTube playlist info
+    console.log('\nℹ️ Getting YouTube playlist info...');
+    const playlistInfo = await supadata.youtube.playlist({
+      id: 'PL0vfts4VzfNjnYhJMfTulea5McZbQLM7G', // Fireship playlist as an example
+    });
+    console.log('ℹ️ Playlist info:', playlistInfo);
+
+    // Example 6: Get YouTube playlist videos
+    console.log('\nℹ️ Getting YouTube playlist videos...');
+    const playlistVideos = await supadata.youtube.playlist.videos({
+      id: 'PL0vfts4VzfNjnYhJMfTulea5McZbQLM7G', // Fireship playlist as an example
+    });
+    console.log('ℹ️ Playlist videos:', playlistVideos);
+
+    // Example 7: Scrape web content
     console.log('\nℹ️ Scraping web content...');
     const webContent = await supadata.web.scrape('https://supadata.ai');
     console.log('ℹ️ Web content:', webContent);
 
-    // Example 3: Map website URLs
+    // Example 8: Map website URLs
     console.log('\nℹ️ Mapping website URLs...');
     const siteMap = await supadata.web.map('https://supadata.ai');
     console.log('ℹ️ Site map:', siteMap);
 
-    // Example 4: Crawl website with limit
+    // Example 9: Crawl website with limit
     console.log('\nℹ️ Crawling website...');
     const crawl = await supadata.web.crawl({
       url: 'https://supadata.ai',
@@ -35,7 +70,7 @@ async function main() {
     });
     console.log('ℹ️ Crawl job started:', crawl);
 
-    // Example 5: Get crawl results
+    // Example 10: Get crawl results
     console.log('\nℹ️ Getting crawl results...');
     const crawlResults = await supadata.web.getCrawlResults(crawl.jobId);
     console.log('ℹ️ Crawl results:', crawlResults);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@supadata/js",
-  "version": "1.0.0",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@supadata/js",
-      "version": "1.0.0",
+      "version": "1.0.4",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.5.14",
@@ -184,25 +184,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.26.7",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.7.tgz",
-      "integrity": "sha512-8NHiL98vsi0mbPQmYAGWwfcFaOy4j2HY49fXJCfuDcdE7fMIsH9a7GdaeXpIBsbT7307WU8KCMp5pUVDNL4f9A==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.10.tgz",
+      "integrity": "sha512-UPYc3SauzZ3JGgj87GgZ89JVdC5dj0AoetR5Bw6wj4niittNyFh6+eOGonYvJ1ao6B8lEa3Q3klS7ADZ53bc5g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.25.9",
-        "@babel/types": "^7.26.7"
+        "@babel/template": "^7.26.9",
+        "@babel/types": "^7.26.10"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.26.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.7.tgz",
-      "integrity": "sha512-kEvgGGgEjRUutvdVvZhbn/BxVt+5VSpwXz1j3WYXQbXDo8KzFOPNG2GQbdAiNq8g6wn1yKk7C/qrke03a84V+w==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.10.tgz",
+      "integrity": "sha512-6aQR2zGE/QFi8JpDLjUZEPYOs7+mhKXm86VaKFiLP35JQwQb6bwUE+XbvkH0EptsYhbNBSUGaUBLKqxH1xSgsA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.26.7"
+        "@babel/types": "^7.26.10"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -434,14 +436,15 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.9.tgz",
-      "integrity": "sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==",
+      "version": "7.26.9",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.26.9.tgz",
+      "integrity": "sha512-qyRplbeIpNZhmzOysF/wFMuP9sctmh2cFzRAZOn1YapxBsE1i9bJIY586R/WBLfLcmcBlM8ROBiQURnnNy+zfA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.25.9",
-        "@babel/parser": "^7.25.9",
-        "@babel/types": "^7.25.9"
+        "@babel/code-frame": "^7.26.2",
+        "@babel/parser": "^7.26.9",
+        "@babel/types": "^7.26.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -466,10 +469,11 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.26.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.7.tgz",
-      "integrity": "sha512-t8kDRGrKXyp6+tjUh7hw2RLyclsW4TRoRvRHtSyAX9Bb5ldlFh+90YAYY6awRXrlB4G5G2izNeGySpATlFzmOg==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.10.tgz",
+      "integrity": "sha512-emqcG3vHrpxUKTrxcblR36dcrcoRDvKmnL/dCL6ZsHaShW80qxCAcNhzQZrpeM765VzEos+xOi4s+r4IXzTwdQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.25.9",
         "@babel/helper-validator-identifier": "^7.25.9"
@@ -485,9 +489,9 @@
       "dev": true
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.24.2.tgz",
-      "integrity": "sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.1.tgz",
+      "integrity": "sha512-kfYGy8IdzTGy+z0vFGvExZtxkFlA4zAxgKEahG9KE1ScBjpQnFsNOX8KTU5ojNru5ed5CVoJYXFtoxaq5nFbjQ==",
       "cpu": [
         "ppc64"
       ],
@@ -502,9 +506,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.24.2.tgz",
-      "integrity": "sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.1.tgz",
+      "integrity": "sha512-dp+MshLYux6j/JjdqVLnMglQlFu+MuVeNrmT5nk6q07wNhCdSnB7QZj+7G8VMUGh1q+vj2Bq8kRsuyA00I/k+Q==",
       "cpu": [
         "arm"
       ],
@@ -519,9 +523,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.24.2.tgz",
-      "integrity": "sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.1.tgz",
+      "integrity": "sha512-50tM0zCJW5kGqgG7fQ7IHvQOcAn9TKiVRuQ/lN0xR+T2lzEFvAi1ZcS8DiksFcEpf1t/GYOeOfCAgDHFpkiSmA==",
       "cpu": [
         "arm64"
       ],
@@ -536,9 +540,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.24.2.tgz",
-      "integrity": "sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.1.tgz",
+      "integrity": "sha512-GCj6WfUtNldqUzYkN/ITtlhwQqGWu9S45vUXs7EIYf+7rCiiqH9bCloatO9VhxsL0Pji+PF4Lz2XXCES+Q8hDw==",
       "cpu": [
         "x64"
       ],
@@ -553,9 +557,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.24.2.tgz",
-      "integrity": "sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.1.tgz",
+      "integrity": "sha512-5hEZKPf+nQjYoSr/elb62U19/l1mZDdqidGfmFutVUjjUZrOazAtwK+Kr+3y0C/oeJfLlxo9fXb1w7L+P7E4FQ==",
       "cpu": [
         "arm64"
       ],
@@ -570,9 +574,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.24.2.tgz",
-      "integrity": "sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.1.tgz",
+      "integrity": "sha512-hxVnwL2Dqs3fM1IWq8Iezh0cX7ZGdVhbTfnOy5uURtao5OIVCEyj9xIzemDi7sRvKsuSdtCAhMKarxqtlyVyfA==",
       "cpu": [
         "x64"
       ],
@@ -587,9 +591,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.24.2.tgz",
-      "integrity": "sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.1.tgz",
+      "integrity": "sha512-1MrCZs0fZa2g8E+FUo2ipw6jw5qqQiH+tERoS5fAfKnRx6NXH31tXBKI3VpmLijLH6yriMZsxJtaXUyFt/8Y4A==",
       "cpu": [
         "arm64"
       ],
@@ -604,9 +608,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.24.2.tgz",
-      "integrity": "sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.1.tgz",
+      "integrity": "sha512-0IZWLiTyz7nm0xuIs0q1Y3QWJC52R8aSXxe40VUxm6BB1RNmkODtW6LHvWRrGiICulcX7ZvyH6h5fqdLu4gkww==",
       "cpu": [
         "x64"
       ],
@@ -621,9 +625,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.24.2.tgz",
-      "integrity": "sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.1.tgz",
+      "integrity": "sha512-NdKOhS4u7JhDKw9G3cY6sWqFcnLITn6SqivVArbzIaf3cemShqfLGHYMx8Xlm/lBit3/5d7kXvriTUGa5YViuQ==",
       "cpu": [
         "arm"
       ],
@@ -638,9 +642,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.24.2.tgz",
-      "integrity": "sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.1.tgz",
+      "integrity": "sha512-jaN3dHi0/DDPelk0nLcXRm1q7DNJpjXy7yWaWvbfkPvI+7XNSc/lDOnCLN7gzsyzgu6qSAmgSvP9oXAhP973uQ==",
       "cpu": [
         "arm64"
       ],
@@ -655,9 +659,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.24.2.tgz",
-      "integrity": "sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.1.tgz",
+      "integrity": "sha512-OJykPaF4v8JidKNGz8c/q1lBO44sQNUQtq1KktJXdBLn1hPod5rE/Hko5ugKKZd+D2+o1a9MFGUEIUwO2YfgkQ==",
       "cpu": [
         "ia32"
       ],
@@ -672,9 +676,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.24.2.tgz",
-      "integrity": "sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.1.tgz",
+      "integrity": "sha512-nGfornQj4dzcq5Vp835oM/o21UMlXzn79KobKlcs3Wz9smwiifknLy4xDCLUU0BWp7b/houtdrgUz7nOGnfIYg==",
       "cpu": [
         "loong64"
       ],
@@ -689,9 +693,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.24.2.tgz",
-      "integrity": "sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.1.tgz",
+      "integrity": "sha512-1osBbPEFYwIE5IVB/0g2X6i1qInZa1aIoj1TdL4AaAb55xIIgbg8Doq6a5BzYWgr+tEcDzYH67XVnTmUzL+nXg==",
       "cpu": [
         "mips64el"
       ],
@@ -706,9 +710,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.24.2.tgz",
-      "integrity": "sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.1.tgz",
+      "integrity": "sha512-/6VBJOwUf3TdTvJZ82qF3tbLuWsscd7/1w+D9LH0W/SqUgM5/JJD0lrJ1fVIfZsqB6RFmLCe0Xz3fmZc3WtyVg==",
       "cpu": [
         "ppc64"
       ],
@@ -723,9 +727,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.24.2.tgz",
-      "integrity": "sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.1.tgz",
+      "integrity": "sha512-nSut/Mx5gnilhcq2yIMLMe3Wl4FK5wx/o0QuuCLMtmJn+WeWYoEGDN1ipcN72g1WHsnIbxGXd4i/MF0gTcuAjQ==",
       "cpu": [
         "riscv64"
       ],
@@ -740,9 +744,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.24.2.tgz",
-      "integrity": "sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.1.tgz",
+      "integrity": "sha512-cEECeLlJNfT8kZHqLarDBQso9a27o2Zd2AQ8USAEoGtejOrCYHNtKP8XQhMDJMtthdF4GBmjR2au3x1udADQQQ==",
       "cpu": [
         "s390x"
       ],
@@ -757,9 +761,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.24.2.tgz",
-      "integrity": "sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.1.tgz",
+      "integrity": "sha512-xbfUhu/gnvSEg+EGovRc+kjBAkrvtk38RlerAzQxvMzlB4fXpCFCeUAYzJvrnhFtdeyVCDANSjJvOvGYoeKzFA==",
       "cpu": [
         "x64"
       ],
@@ -774,9 +778,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.24.2.tgz",
-      "integrity": "sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.1.tgz",
+      "integrity": "sha512-O96poM2XGhLtpTh+s4+nP7YCCAfb4tJNRVZHfIE7dgmax+yMP2WgMd2OecBuaATHKTHsLWHQeuaxMRnCsH8+5g==",
       "cpu": [
         "arm64"
       ],
@@ -791,9 +795,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.24.2.tgz",
-      "integrity": "sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.1.tgz",
+      "integrity": "sha512-X53z6uXip6KFXBQ+Krbx25XHV/NCbzryM6ehOAeAil7X7oa4XIq+394PWGnwaSQ2WRA0KI6PUO6hTO5zeF5ijA==",
       "cpu": [
         "x64"
       ],
@@ -808,9 +812,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.24.2.tgz",
-      "integrity": "sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.1.tgz",
+      "integrity": "sha512-Na9T3szbXezdzM/Kfs3GcRQNjHzM6GzFBeU1/6IV/npKP5ORtp9zbQjvkDJ47s6BCgaAZnnnu/cY1x342+MvZg==",
       "cpu": [
         "arm64"
       ],
@@ -825,9 +829,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.24.2.tgz",
-      "integrity": "sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.1.tgz",
+      "integrity": "sha512-T3H78X2h1tszfRSf+txbt5aOp/e7TAz3ptVKu9Oyir3IAOFPGV6O9c2naym5TOriy1l0nNf6a4X5UXRZSGX/dw==",
       "cpu": [
         "x64"
       ],
@@ -842,9 +846,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.24.2.tgz",
-      "integrity": "sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.1.tgz",
+      "integrity": "sha512-2H3RUvcmULO7dIE5EWJH8eubZAI4xw54H1ilJnRNZdeo8dTADEZ21w6J22XBkXqGJbe0+wnNJtw3UXRoLJnFEg==",
       "cpu": [
         "x64"
       ],
@@ -859,9 +863,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.24.2.tgz",
-      "integrity": "sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.1.tgz",
+      "integrity": "sha512-GE7XvrdOzrb+yVKB9KsRMq+7a2U/K5Cf/8grVFRAGJmfADr/e/ODQ134RK2/eeHqYV5eQRFxb1hY7Nr15fv1NQ==",
       "cpu": [
         "arm64"
       ],
@@ -876,9 +880,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.24.2.tgz",
-      "integrity": "sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.1.tgz",
+      "integrity": "sha512-uOxSJCIcavSiT6UnBhBzE8wy3n0hOkJsBOzy7HDAuTDE++1DJMRRVCPGisULScHL+a/ZwdXPpXD3IyFKjA7K8A==",
       "cpu": [
         "ia32"
       ],
@@ -893,9 +897,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.24.2.tgz",
-      "integrity": "sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.1.tgz",
+      "integrity": "sha512-Y1EQdcfwMSeQN/ujR5VayLOJ1BHaK+ssyk0AEzPjC+t1lITgsnccPqFjb6V+LsTp/9Iov4ysfjxLaGJ9RPtkVg==",
       "cpu": [
         "x64"
       ],
@@ -1375,9 +1379,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.32.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.32.1.tgz",
-      "integrity": "sha512-/pqA4DmqyCm8u5YIDzIdlLcEmuvxb0v8fZdFhVMszSpDTgbQKdw3/mB3eMUHIbubtJ6F9j+LtmyCnHTEqIHyzA==",
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.36.0.tgz",
+      "integrity": "sha512-jgrXjjcEwN6XpZXL0HUeOVGfjXhPyxAbbhD0BlXUB+abTOpbPiN5Wb3kOT7yb+uEtATNYF5x5gIfwutmuBA26w==",
       "cpu": [
         "arm"
       ],
@@ -1389,9 +1393,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.32.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.32.1.tgz",
-      "integrity": "sha512-If3PDskT77q7zgqVqYuj7WG3WC08G1kwXGVFi9Jr8nY6eHucREHkfpX79c0ACAjLj3QIWKPJR7w4i+f5EdLH5Q==",
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.36.0.tgz",
+      "integrity": "sha512-NyfuLvdPdNUfUNeYKUwPwKsE5SXa2J6bCt2LdB/N+AxShnkpiczi3tcLJrm5mA+eqpy0HmaIY9F6XCa32N5yzg==",
       "cpu": [
         "arm64"
       ],
@@ -1403,9 +1407,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.32.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.32.1.tgz",
-      "integrity": "sha512-zCpKHioQ9KgZToFp5Wvz6zaWbMzYQ2LJHQ+QixDKq52KKrF65ueu6Af4hLlLWHjX1Wf/0G5kSJM9PySW9IrvHA==",
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.36.0.tgz",
+      "integrity": "sha512-JQ1Jk5G4bGrD4pWJQzWsD8I1n1mgPXq33+/vP4sk8j/z/C2siRuxZtaUA7yMTf71TCZTZl/4e1bfzwUmFb3+rw==",
       "cpu": [
         "arm64"
       ],
@@ -1417,9 +1421,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.32.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.32.1.tgz",
-      "integrity": "sha512-sFvF+t2+TyUo/ZQqUcifrJIgznx58oFZbdHS9TvHq3xhPVL9nOp+yZ6LKrO9GWTP+6DbFtoyLDbjTpR62Mbr3Q==",
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.36.0.tgz",
+      "integrity": "sha512-6c6wMZa1lrtiRsbDziCmjE53YbTkxMYhhnWnSW8R/yqsM7a6mSJ3uAVT0t8Y/DGt7gxUWYuFM4bwWk9XCJrFKA==",
       "cpu": [
         "x64"
       ],
@@ -1431,9 +1435,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.32.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.32.1.tgz",
-      "integrity": "sha512-NbOa+7InvMWRcY9RG+B6kKIMD/FsnQPH0MWUvDlQB1iXnF/UcKSudCXZtv4lW+C276g3w5AxPbfry5rSYvyeYA==",
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.36.0.tgz",
+      "integrity": "sha512-KXVsijKeJXOl8QzXTsA+sHVDsFOmMCdBRgFmBb+mfEb/7geR7+C8ypAml4fquUt14ZyVXaw2o1FWhqAfOvA4sg==",
       "cpu": [
         "arm64"
       ],
@@ -1445,9 +1449,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.32.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.32.1.tgz",
-      "integrity": "sha512-JRBRmwvHPXR881j2xjry8HZ86wIPK2CcDw0EXchE1UgU0ubWp9nvlT7cZYKc6bkypBt745b4bglf3+xJ7hXWWw==",
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.36.0.tgz",
+      "integrity": "sha512-dVeWq1ebbvByI+ndz4IJcD4a09RJgRYmLccwlQ8bPd4olz3Y213uf1iwvc7ZaxNn2ab7bjc08PrtBgMu6nb4pQ==",
       "cpu": [
         "x64"
       ],
@@ -1459,9 +1463,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.32.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.32.1.tgz",
-      "integrity": "sha512-PKvszb+9o/vVdUzCCjL0sKHukEQV39tD3fepXxYrHE3sTKrRdCydI7uldRLbjLmDA3TFDmh418XH19NOsDRH8g==",
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.36.0.tgz",
+      "integrity": "sha512-bvXVU42mOVcF4le6XSjscdXjqx8okv4n5vmwgzcmtvFdifQ5U4dXFYaCB87namDRKlUL9ybVtLQ9ztnawaSzvg==",
       "cpu": [
         "arm"
       ],
@@ -1473,9 +1477,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.32.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.32.1.tgz",
-      "integrity": "sha512-9WHEMV6Y89eL606ReYowXuGF1Yb2vwfKWKdD1A5h+OYnPZSJvxbEjxTRKPgi7tkP2DSnW0YLab1ooy+i/FQp/Q==",
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.36.0.tgz",
+      "integrity": "sha512-JFIQrDJYrxOnyDQGYkqnNBtjDwTgbasdbUiQvcU8JmGDfValfH1lNpng+4FWlhaVIR4KPkeddYjsVVbmJYvDcg==",
       "cpu": [
         "arm"
       ],
@@ -1487,9 +1491,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.32.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.32.1.tgz",
-      "integrity": "sha512-tZWc9iEt5fGJ1CL2LRPw8OttkCBDs+D8D3oEM8mH8S1ICZCtFJhD7DZ3XMGM8kpqHvhGUTvNUYVDnmkj4BDXnw==",
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.36.0.tgz",
+      "integrity": "sha512-KqjYVh3oM1bj//5X7k79PSCZ6CvaVzb7Qs7VMWS+SlWB5M8p3FqufLP9VNp4CazJ0CsPDLwVD9r3vX7Ci4J56A==",
       "cpu": [
         "arm64"
       ],
@@ -1501,9 +1505,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.32.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.32.1.tgz",
-      "integrity": "sha512-FTYc2YoTWUsBz5GTTgGkRYYJ5NGJIi/rCY4oK/I8aKowx1ToXeoVVbIE4LGAjsauvlhjfl0MYacxClLld1VrOw==",
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.36.0.tgz",
+      "integrity": "sha512-QiGnhScND+mAAtfHqeT+cB1S9yFnNQ/EwCg5yE3MzoaZZnIV0RV9O5alJAoJKX/sBONVKeZdMfO8QSaWEygMhw==",
       "cpu": [
         "arm64"
       ],
@@ -1515,9 +1519,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-      "version": "4.32.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.32.1.tgz",
-      "integrity": "sha512-F51qLdOtpS6P1zJVRzYM0v6MrBNypyPEN1GfMiz0gPu9jN8ScGaEFIZQwteSsGKg799oR5EaP7+B2jHgL+d+Kw==",
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.36.0.tgz",
+      "integrity": "sha512-1ZPyEDWF8phd4FQtTzMh8FQwqzvIjLsl6/84gzUxnMNFBtExBtpL51H67mV9xipuxl1AEAerRBgBwFNpkw8+Lg==",
       "cpu": [
         "loong64"
       ],
@@ -1529,9 +1533,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.32.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.32.1.tgz",
-      "integrity": "sha512-wO0WkfSppfX4YFm5KhdCCpnpGbtgQNj/tgvYzrVYFKDpven8w2N6Gg5nB6w+wAMO3AIfSTWeTjfVe+uZ23zAlg==",
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.36.0.tgz",
+      "integrity": "sha512-VMPMEIUpPFKpPI9GZMhJrtu8rxnp6mJR3ZzQPykq4xc2GmdHj3Q4cA+7avMyegXy4n1v+Qynr9fR88BmyO74tg==",
       "cpu": [
         "ppc64"
       ],
@@ -1543,9 +1547,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.32.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.32.1.tgz",
-      "integrity": "sha512-iWswS9cIXfJO1MFYtI/4jjlrGb/V58oMu4dYJIKnR5UIwbkzR0PJ09O0PDZT0oJ3LYWXBSWahNf/Mjo6i1E5/g==",
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.36.0.tgz",
+      "integrity": "sha512-ttE6ayb/kHwNRJGYLpuAvB7SMtOeQnVXEIpMtAvx3kepFQeowVED0n1K9nAdraHUPJ5hydEMxBpIR7o4nrm8uA==",
       "cpu": [
         "riscv64"
       ],
@@ -1557,9 +1561,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.32.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.32.1.tgz",
-      "integrity": "sha512-RKt8NI9tebzmEthMnfVgG3i/XeECkMPS+ibVZjZ6mNekpbbUmkNWuIN2yHsb/mBPyZke4nlI4YqIdFPgKuoyQQ==",
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.36.0.tgz",
+      "integrity": "sha512-4a5gf2jpS0AIe7uBjxDeUMNcFmaRTbNv7NxI5xOCs4lhzsVyGR/0qBXduPnoWf6dGC365saTiwag8hP1imTgag==",
       "cpu": [
         "s390x"
       ],
@@ -1571,9 +1575,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.32.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.32.1.tgz",
-      "integrity": "sha512-WQFLZ9c42ECqEjwg/GHHsouij3pzLXkFdz0UxHa/0OM12LzvX7DzedlY0SIEly2v18YZLRhCRoHZDxbBSWoGYg==",
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.36.0.tgz",
+      "integrity": "sha512-5KtoW8UWmwFKQ96aQL3LlRXX16IMwyzMq/jSSVIIyAANiE1doaQsx/KRyhAvpHlPjPiSU/AYX/8m+lQ9VToxFQ==",
       "cpu": [
         "x64"
       ],
@@ -1585,9 +1589,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.32.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.32.1.tgz",
-      "integrity": "sha512-BLoiyHDOWoS3uccNSADMza6V6vCNiphi94tQlVIL5de+r6r/CCQuNnerf+1g2mnk2b6edp5dk0nhdZ7aEjOBsA==",
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.36.0.tgz",
+      "integrity": "sha512-sycrYZPrv2ag4OCvaN5js+f01eoZ2U+RmT5as8vhxiFz+kxwlHrsxOwKPSA8WyS+Wc6Epid9QeI/IkQ9NkgYyQ==",
       "cpu": [
         "x64"
       ],
@@ -1599,9 +1603,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.32.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.32.1.tgz",
-      "integrity": "sha512-w2l3UnlgYTNNU+Z6wOR8YdaioqfEnwPjIsJ66KxKAf0p+AuL2FHeTX6qvM+p/Ue3XPBVNyVSfCrfZiQh7vZHLQ==",
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.36.0.tgz",
+      "integrity": "sha512-qbqt4N7tokFwwSVlWDsjfoHgviS3n/vZ8LK0h1uLG9TYIRuUTJC88E1xb3LM2iqZ/WTqNQjYrtmtGmrmmawB6A==",
       "cpu": [
         "arm64"
       ],
@@ -1613,9 +1617,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.32.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.32.1.tgz",
-      "integrity": "sha512-Am9H+TGLomPGkBnaPWie4F3x+yQ2rr4Bk2jpwy+iV+Gel9jLAu/KqT8k3X4jxFPW6Zf8OMnehyutsd+eHoq1WQ==",
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.36.0.tgz",
+      "integrity": "sha512-t+RY0JuRamIocMuQcfwYSOkmdX9dtkr1PbhKW42AMvaDQa+jOdpUYysroTF/nuPpAaQMWp7ye+ndlmmthieJrQ==",
       "cpu": [
         "ia32"
       ],
@@ -1627,9 +1631,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.32.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.32.1.tgz",
-      "integrity": "sha512-ar80GhdZb4DgmW3myIS9nRFYcpJRSME8iqWgzH2i44u+IdrzmiXVxeFnExQ5v4JYUSpg94bWjevMG8JHf1Da5Q==",
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.36.0.tgz",
+      "integrity": "sha512-aRXd7tRZkWLqGbChgcMMDEHjOKudo1kChb1Jt1IfR8cY/KIpgNviLeJy5FUb9IpSuQj8dU2fAYNMPW/hLKOSTw==",
       "cpu": [
         "x64"
       ],
@@ -2422,9 +2426,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.2.tgz",
-      "integrity": "sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.1.tgz",
+      "integrity": "sha512-BGO5LtrGC7vxnqucAe/rmvKdJllfGaYWdyABvyMoXQlfYMb2bbRuReWR5tEGE//4LcNJj9XrkovTqNYRFZHAMQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -2435,31 +2439,31 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.24.2",
-        "@esbuild/android-arm": "0.24.2",
-        "@esbuild/android-arm64": "0.24.2",
-        "@esbuild/android-x64": "0.24.2",
-        "@esbuild/darwin-arm64": "0.24.2",
-        "@esbuild/darwin-x64": "0.24.2",
-        "@esbuild/freebsd-arm64": "0.24.2",
-        "@esbuild/freebsd-x64": "0.24.2",
-        "@esbuild/linux-arm": "0.24.2",
-        "@esbuild/linux-arm64": "0.24.2",
-        "@esbuild/linux-ia32": "0.24.2",
-        "@esbuild/linux-loong64": "0.24.2",
-        "@esbuild/linux-mips64el": "0.24.2",
-        "@esbuild/linux-ppc64": "0.24.2",
-        "@esbuild/linux-riscv64": "0.24.2",
-        "@esbuild/linux-s390x": "0.24.2",
-        "@esbuild/linux-x64": "0.24.2",
-        "@esbuild/netbsd-arm64": "0.24.2",
-        "@esbuild/netbsd-x64": "0.24.2",
-        "@esbuild/openbsd-arm64": "0.24.2",
-        "@esbuild/openbsd-x64": "0.24.2",
-        "@esbuild/sunos-x64": "0.24.2",
-        "@esbuild/win32-arm64": "0.24.2",
-        "@esbuild/win32-ia32": "0.24.2",
-        "@esbuild/win32-x64": "0.24.2"
+        "@esbuild/aix-ppc64": "0.25.1",
+        "@esbuild/android-arm": "0.25.1",
+        "@esbuild/android-arm64": "0.25.1",
+        "@esbuild/android-x64": "0.25.1",
+        "@esbuild/darwin-arm64": "0.25.1",
+        "@esbuild/darwin-x64": "0.25.1",
+        "@esbuild/freebsd-arm64": "0.25.1",
+        "@esbuild/freebsd-x64": "0.25.1",
+        "@esbuild/linux-arm": "0.25.1",
+        "@esbuild/linux-arm64": "0.25.1",
+        "@esbuild/linux-ia32": "0.25.1",
+        "@esbuild/linux-loong64": "0.25.1",
+        "@esbuild/linux-mips64el": "0.25.1",
+        "@esbuild/linux-ppc64": "0.25.1",
+        "@esbuild/linux-riscv64": "0.25.1",
+        "@esbuild/linux-s390x": "0.25.1",
+        "@esbuild/linux-x64": "0.25.1",
+        "@esbuild/netbsd-arm64": "0.25.1",
+        "@esbuild/netbsd-x64": "0.25.1",
+        "@esbuild/openbsd-arm64": "0.25.1",
+        "@esbuild/openbsd-x64": "0.25.1",
+        "@esbuild/sunos-x64": "0.25.1",
+        "@esbuild/win32-arm64": "0.25.1",
+        "@esbuild/win32-ia32": "0.25.1",
+        "@esbuild/win32-x64": "0.25.1"
       }
     },
     "node_modules/escalade": {
@@ -4309,9 +4313,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.32.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.32.1.tgz",
-      "integrity": "sha512-z+aeEsOeEa3mEbS1Tjl6sAZ8NE3+AalQz1RJGj81M+fizusbdDMoEJwdJNHfaB40Scr4qNu+welOfes7maKonA==",
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.36.0.tgz",
+      "integrity": "sha512-zwATAXNQxUcd40zgtQG0ZafcRK4g004WtEl7kbuhTWPvf07PsfohXl39jVUvPF7jvNAIkKPQ2XrsDlWuxBd++Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4325,25 +4329,25 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.32.1",
-        "@rollup/rollup-android-arm64": "4.32.1",
-        "@rollup/rollup-darwin-arm64": "4.32.1",
-        "@rollup/rollup-darwin-x64": "4.32.1",
-        "@rollup/rollup-freebsd-arm64": "4.32.1",
-        "@rollup/rollup-freebsd-x64": "4.32.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.32.1",
-        "@rollup/rollup-linux-arm-musleabihf": "4.32.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.32.1",
-        "@rollup/rollup-linux-arm64-musl": "4.32.1",
-        "@rollup/rollup-linux-loongarch64-gnu": "4.32.1",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.32.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.32.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.32.1",
-        "@rollup/rollup-linux-x64-gnu": "4.32.1",
-        "@rollup/rollup-linux-x64-musl": "4.32.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.32.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.32.1",
-        "@rollup/rollup-win32-x64-msvc": "4.32.1",
+        "@rollup/rollup-android-arm-eabi": "4.36.0",
+        "@rollup/rollup-android-arm64": "4.36.0",
+        "@rollup/rollup-darwin-arm64": "4.36.0",
+        "@rollup/rollup-darwin-x64": "4.36.0",
+        "@rollup/rollup-freebsd-arm64": "4.36.0",
+        "@rollup/rollup-freebsd-x64": "4.36.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.36.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.36.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.36.0",
+        "@rollup/rollup-linux-arm64-musl": "4.36.0",
+        "@rollup/rollup-linux-loongarch64-gnu": "4.36.0",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.36.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.36.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.36.0",
+        "@rollup/rollup-linux-x64-gnu": "4.36.0",
+        "@rollup/rollup-linux-x64-musl": "4.36.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.36.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.36.0",
+        "@rollup/rollup-win32-x64-msvc": "4.36.0",
         "fsevents": "~2.3.2"
       }
     },
@@ -4673,17 +4677,20 @@
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.10.tgz",
-      "integrity": "sha512-Zc+8eJlFMvgatPZTl6A9L/yht8QqdmUNtURHaKZLmKBE12hNPSrqNkUp2cs3M/UKmNVVAMFQYSjYIVHDjW5zew==",
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.12.tgz",
+      "integrity": "sha512-qkf4trmKSIiMTs/E63cxH+ojC2unam7rJ0WrauAzpT3ECNTxGRMlaXxVbfxMUC/w0LaYk6jQ4y/nGR9uBO3tww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fdir": "^6.4.2",
+        "fdir": "^6.4.3",
         "picomatch": "^4.0.2"
       },
       "engines": {
         "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
     "node_modules/tinyglobby/node_modules/fdir": {
@@ -4817,27 +4824,27 @@
       }
     },
     "node_modules/tsup": {
-      "version": "8.3.6",
-      "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.3.6.tgz",
-      "integrity": "sha512-XkVtlDV/58S9Ye0JxUUTcrQk4S+EqlOHKzg6Roa62rdjL1nGWNUstG0xgI4vanHdfIpjP448J8vlN0oK6XOJ5g==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.4.0.tgz",
+      "integrity": "sha512-b+eZbPCjz10fRryaAA7C8xlIHnf8VnsaRqydheLIqwG/Mcpfk8Z5zp3HayX7GaTygkigHl5cBUs+IhcySiIexQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "bundle-require": "^5.0.0",
+        "bundle-require": "^5.1.0",
         "cac": "^6.7.14",
-        "chokidar": "^4.0.1",
-        "consola": "^3.2.3",
-        "debug": "^4.3.7",
-        "esbuild": "^0.24.0",
+        "chokidar": "^4.0.3",
+        "consola": "^3.4.0",
+        "debug": "^4.4.0",
+        "esbuild": "^0.25.0",
         "joycon": "^3.1.1",
         "picocolors": "^1.1.1",
         "postcss-load-config": "^6.0.1",
         "resolve-from": "^5.0.0",
-        "rollup": "^4.24.0",
+        "rollup": "^4.34.8",
         "source-map": "0.8.0-beta.0",
         "sucrase": "^3.35.0",
-        "tinyexec": "^0.3.1",
-        "tinyglobby": "^0.2.9",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.11",
         "tree-kill": "^1.2.2"
       },
       "bin": {

--- a/src/__tests__/supadata.test.ts
+++ b/src/__tests__/supadata.test.ts
@@ -1,10 +1,11 @@
-import { Supadata } from '../index.js';
 import fetchMock from 'jest-fetch-mock';
+import { Supadata } from '../index.js';
 import type {
+  Map,
+  Scrape,
   Transcript,
   TranslatedTranscript,
-  Scrape,
-  Map,
+  YoutubeVideo,
 } from '../types.js';
 
 fetchMock.enableMocks();
@@ -74,6 +75,332 @@ describe('Supadata SDK', () => {
           },
         })
       );
+    });
+
+    it('should get the video info', async () => {
+      const videoId = 'pEfrdAtAmqk';
+      const mockResponse: YoutubeVideo = {
+        id: videoId,
+        duration: 1002,
+        description:
+          'The programming iceberg is complete roadmap to the loved, ...',
+        title: 'God-Tier Developer Roadmap',
+        channel: { id: 'UCsBjURrPoezykLs9EqgamOA', name: 'Fireship' },
+        tags: ['#iceberg', '#learntocode', '#programming'],
+        thumbnail: 'https://i.ytimg.com/vi/pEfrdAtAmqk/maxresdefault.jpg',
+        uploadDate: '2022-08-24T00:00:00.000Z',
+        viewCount: 7388353,
+        likeCount: 262086,
+        transcriptLanguages: ['en'],
+      };
+
+      fetchMock.mockResponse(JSON.stringify(mockResponse), {
+        headers: { 'content-type': 'application/json' },
+      });
+
+      const result = await supadata.youtube.video({ id: videoId });
+
+      expect(result).toEqual(mockResponse);
+      expect(fetchMock).toHaveBeenCalledWith(
+        `https://api.supadata.ai/v1/youtube/video?id=${videoId}`,
+        expect.objectContaining({
+          method: 'GET',
+          headers: {
+            'x-api-key': 'test-api-key',
+            'Content-Type': 'application/json',
+          },
+        })
+      );
+    });
+
+    it("should throw error when video doesn't exist", async () => {
+      const videoId = 'pEfrdAtmqk';
+      const mockResponse = {
+        error: 'not-found',
+        message: 'The requested item could not be found',
+      };
+
+      fetchMock.mockResponseOnce(JSON.stringify(mockResponse), {
+        status: 404,
+        headers: { 'content-type': 'application/json' },
+      });
+
+      await expect(supadata.youtube.video({ id: videoId })).rejects.toThrow(
+        'Endpoint does not exist'
+      );
+    });
+
+    it('should get the channel info', async () => {
+      const channelId = 'UCsBjURrPoezykLs9EqgamOA';
+      const mockResponse = {
+        id: channelId,
+        name: 'Fireship',
+        handle: '@Fireship',
+        description:
+          'High-intensity ⚡ code tutorials and tech news to help you ship your app faster. New videos every week covering the topics every programmer should know. ',
+        videoCount: 719,
+        subscriberCount: 3770000,
+        thumbnail:
+          'https://yt3.googleusercontent.com/ytc/AIdro_mKzklyPPhghBJQH5H3HpZ108YcE618DBRLAvRUD1AjKNw=s160-c-k-c0x00ffffff-no-rj',
+        banner:
+          'https://yt3.googleusercontent.com/62Kw34f1ysmycFceeNIFGsWpRDyqgDUSn2mAn29gwv7axMjN4NUVkJWqwEi4XKBE0016l7C4=w2560-fcrop64=1,00005a57ffffa5a8-k-c0xffffffff-no-nd-rj',
+      };
+
+      fetchMock.mockResponse(JSON.stringify(mockResponse), {
+        headers: { 'content-type': 'application/json' },
+      });
+
+      const result = await supadata.youtube.channel({ id: channelId });
+
+      expect(result).toEqual(mockResponse);
+      expect(fetchMock).toHaveBeenCalledWith(
+        `https://api.supadata.ai/v1/youtube/channel?id=${channelId}`,
+        expect.objectContaining({
+          method: 'GET',
+          headers: {
+            'x-api-key': 'test-api-key',
+            'Content-Type': 'application/json',
+          },
+        })
+      );
+    });
+
+    it("should throw error when channel doesn't exist", async () => {
+      const channelId = 'UCsBjURrPoezyLs9EqgamOA';
+      const mockResponse = {
+        error: 'not-found',
+        message: 'The requested item could not be found',
+        details: 'The requested item could not be found.',
+      };
+
+      fetchMock.mockResponseOnce(JSON.stringify(mockResponse), {
+        status: 404,
+        headers: { 'content-type': 'application/json' },
+      });
+
+      await expect(supadata.youtube.channel({ id: channelId })).rejects.toThrow(
+        'Endpoint does not exist'
+      );
+    });
+
+    it('should get a list of videos in the channel without limit', async () => {
+      const channelId = 'UCsBjURrPoezyLs9EqgamOA';
+      const mockResponse = {
+        videoIds: ['PQ2WjtaPfXU', 'UIVADiGfwWc'],
+      };
+
+      fetchMock.mockResponse(JSON.stringify(mockResponse), {
+        headers: { 'content-type': 'application/json' },
+      });
+
+      const result = await supadata.youtube.channel.videos({ id: channelId });
+
+      expect(result).toEqual(mockResponse);
+      expect(fetchMock).toHaveBeenCalledWith(
+        `https://api.supadata.ai/v1/youtube/channel/videos?id=${channelId}`,
+        expect.objectContaining({
+          method: 'GET',
+          headers: {
+            'x-api-key': 'test-api-key',
+            'Content-Type': 'application/json',
+          },
+        })
+      );
+    });
+
+    it('should get a list of videos in the channel with limit', async () => {
+      const channelId = 'UCsBjURrPoezyLs9EqgamOA';
+      const mockResponse = {
+        videoIds: ['PQ2WjtaPfXU', 'UIVADiGfwWc'],
+      };
+
+      fetchMock.mockResponse(JSON.stringify(mockResponse), {
+        headers: { 'content-type': 'application/json' },
+      });
+
+      const limit = 2;
+      const result = await supadata.youtube.channel.videos({
+        id: channelId,
+        limit: limit,
+      });
+
+      expect(result).toEqual(mockResponse);
+      expect(fetchMock).toHaveBeenCalledWith(
+        `https://api.supadata.ai/v1/youtube/channel/videos?id=${channelId}&limit=${limit}`,
+        expect.objectContaining({
+          method: 'GET',
+          headers: {
+            'x-api-key': 'test-api-key',
+            'Content-Type': 'application/json',
+          },
+        })
+      );
+    });
+
+    it("should throw error when channel doesn't exist", async () => {
+      const channelId = 'UCsBjURrPoezyLs9EqgamOA';
+      const mockResponse = {
+        error: 'not-found',
+        message: 'The requested item could not be found',
+        details: 'The requested item could not be found.',
+      };
+
+      fetchMock.mockResponseOnce(JSON.stringify(mockResponse), {
+        status: 404,
+        headers: { 'content-type': 'application/json' },
+      });
+
+      await expect(
+        supadata.youtube.channel.videos({ id: channelId })
+      ).rejects.toThrow('Endpoint does not exist');
+    });
+
+    it('should throw an error with invalid limit', async () => {
+      await expect(
+        supadata.youtube.channel.videos({ id: 'test-id', limit: 0 })
+      ).rejects.toThrow('Invalid limit.');
+
+      await expect(
+        supadata.youtube.channel.videos({ id: 'test-id', limit: -1 })
+      ).rejects.toThrow('Invalid limit.');
+
+      await expect(
+        supadata.youtube.channel.videos({ id: 'test-id', limit: 10000 })
+      ).rejects.toThrow('Invalid limit.');
+    });
+
+    it('should get the playlist info', async () => {
+      const playlistId = 'PL0vfts4VzfNjQOM9VClyL5R0LeuTxlAR3';
+      const mockResponse = {
+        id: playlistId,
+        title: 'CS101',
+        videoCount: 17,
+        viewCount: 440901,
+        lastUpdated: '2024-07-06T00:00:00.000Z',
+        channel: { id: 'UCsBjURrPoezykLs9EqgamOA', name: 'Fireship' },
+      };
+
+      fetchMock.mockResponse(JSON.stringify(mockResponse), {
+        headers: { 'content-type': 'application/json' },
+      });
+
+      const result = await supadata.youtube.playlist({ id: playlistId });
+
+      expect(result).toEqual(mockResponse);
+      expect(fetchMock).toHaveBeenCalledWith(
+        `https://api.supadata.ai/v1/youtube/playlist?id=${playlistId}`,
+        expect.objectContaining({
+          method: 'GET',
+          headers: {
+            'x-api-key': 'test-api-key',
+            'Content-Type': 'application/json',
+          },
+        })
+      );
+    });
+
+    it("should throw error when playlist doesn't exist", async () => {
+      const playlistId = 'PL0vfts4VzfNjQOM9VClyL50LeuTxlAR3';
+      const mockResponse = {
+        error: 'not-found',
+        message: 'The requested item could not be found',
+        details: 'The requested item could not be found.',
+      };
+
+      fetchMock.mockResponseOnce(JSON.stringify(mockResponse), {
+        status: 404,
+        headers: { 'content-type': 'application/json' },
+      });
+
+      await expect(
+        supadata.youtube.playlist({ id: playlistId })
+      ).rejects.toThrow('Endpoint does not exist');
+    });
+
+    it('should get a list of videos in the playlist without limit', async () => {
+      const playlistId = 'PL0vfts4VzfNjQOM9VClyL5R0LeuTxlAR3';
+      const mockResponse = {
+        videoIds: ['PQ2WjtaPfXU', 'UIVADiGfwWc'],
+      };
+
+      fetchMock.mockResponse(JSON.stringify(mockResponse), {
+        headers: { 'content-type': 'application/json' },
+      });
+
+      const result = await supadata.youtube.playlist.videos({ id: playlistId });
+
+      expect(result).toEqual(mockResponse);
+      expect(fetchMock).toHaveBeenCalledWith(
+        `https://api.supadata.ai/v1/youtube/playlist/videos?id=${playlistId}`,
+        expect.objectContaining({
+          method: 'GET',
+          headers: {
+            'x-api-key': 'test-api-key',
+            'Content-Type': 'application/json',
+          },
+        })
+      );
+    });
+
+    it('should get a list of videos in the playlist with limit', async () => {
+      const playlistId = 'PL0vfts4VzfNjQOM9VClyL5R0LeuTxlAR3';
+      const mockResponse = {
+        videoIds: ['PQ2WjtaPfXU', 'UIVADiGfwWc'],
+      };
+
+      fetchMock.mockResponse(JSON.stringify(mockResponse), {
+        headers: { 'content-type': 'application/json' },
+      });
+
+      const limit = 2;
+      const result = await supadata.youtube.playlist.videos({
+        id: playlistId,
+        limit: limit,
+      });
+
+      expect(result).toEqual(mockResponse);
+      expect(fetchMock).toHaveBeenCalledWith(
+        `https://api.supadata.ai/v1/youtube/playlist/videos?id=${playlistId}&limit=${limit}`,
+        expect.objectContaining({
+          method: 'GET',
+          headers: {
+            'x-api-key': 'test-api-key',
+            'Content-Type': 'application/json',
+          },
+        })
+      );
+    });
+
+    it("should throw error when playlist doesn't exist", async () => {
+      const playlistId = 'PL0vfts4VzfNjQOM9VClyL50LeuTxlAR3';
+      const mockResponse = {
+        error: 'not-found',
+        message: 'The requested item could not be found',
+        details: 'The requested item could not be found.',
+      };
+
+      fetchMock.mockResponseOnce(JSON.stringify(mockResponse), {
+        status: 404,
+        headers: { 'content-type': 'application/json' },
+      });
+
+      await expect(
+        supadata.youtube.playlist.videos({ id: playlistId })
+      ).rejects.toThrow('Endpoint does not exist');
+    });
+
+    it('should throw an error with invalid limit', async () => {
+      await expect(
+        supadata.youtube.playlist.videos({ id: 'test-id', limit: 0 })
+      ).rejects.toThrow('Invalid limit.');
+
+      await expect(
+        supadata.youtube.playlist.videos({ id: 'test-id', limit: -1 })
+      ).rejects.toThrow('Invalid limit.');
+
+      await expect(
+        supadata.youtube.playlist.videos({ id: 'test-id', limit: 10000 })
+      ).rejects.toThrow('Invalid limit.');
     });
   });
 

--- a/src/__tests__/supadata.test.ts
+++ b/src/__tests__/supadata.test.ts
@@ -1,8 +1,8 @@
 import fetchMock from 'jest-fetch-mock';
 import { Supadata } from '../index.js';
 import type {
-  Map,
   Scrape,
+  SiteMap,
   Transcript,
   TranslatedTranscript,
   YoutubeVideo,
@@ -435,7 +435,7 @@ describe('Supadata SDK', () => {
     });
 
     it('should map website', async () => {
-      const mockResponse: Map = {
+      const mockResponse: SiteMap = {
         urls: ['https://supadata.ai', 'https://supadata.ai/docs'],
       };
 

--- a/src/services/web.ts
+++ b/src/services/web.ts
@@ -1,5 +1,5 @@
 import { BaseClient } from '../client.js';
-import { Scrape, Map, CrawlRequest, Crawl, CrawlJob } from '../types.js';
+import { Crawl, CrawlJob, CrawlRequest, Scrape, SiteMap } from '../types.js';
 
 export class WebService extends BaseClient {
   /**
@@ -18,8 +18,8 @@ export class WebService extends BaseClient {
    * @param url - URL of the webpage to map
    * @returns A promise that resolves to a map of URLs found on the page
    */
-  async map(url: string): Promise<Map> {
-    return this.fetch<Map>('/web/map', { url });
+  async map(url: string): Promise<SiteMap> {
+    return this.fetch<SiteMap>('/web/map', { url });
   }
 
   /**

--- a/src/services/youtube.ts
+++ b/src/services/youtube.ts
@@ -1,5 +1,12 @@
 import { BaseClient } from '../client.js';
-import { Transcript, TranslatedTranscript } from '../types.js';
+import {
+  SupadataError,
+  Transcript,
+  TranslatedTranscript,
+  YoutubeChannel,
+  YoutubePlaylist,
+  YoutubeVideo,
+} from '../types.js';
 
 /**
  * Ensures exactly one property from the specified keys is provided.
@@ -19,6 +26,22 @@ export type TranscriptParams = {
 
 export interface TranslateParams extends Omit<TranscriptParams, 'lang'> {
   lang: string;
+}
+
+export interface VideoParams {
+  id: string;
+}
+
+export interface ChannelParams extends VideoParams {}
+
+export interface ChannelVideosParams extends ChannelParams {
+  limit?: number;
+}
+
+export interface PlaylistParams extends VideoParams {}
+
+export interface PlaylistVideosParams extends PlaylistParams {
+  limit?: number;
 }
 
 export class YouTubeService extends BaseClient {
@@ -51,5 +74,88 @@ export class YouTubeService extends BaseClient {
       '/youtube/transcript/translate',
       params
     );
+  }
+
+  /**
+   * Fetches a YouTube video based on the provided parameters.
+   *
+   * @param params - The parameters required to fetch the YouTube video.
+   * @param params.id - The YouTube video ID.
+   * @returns A promise that resolves to a `YoutubeVideo` object.
+   */
+  async video(params: VideoParams): Promise<YoutubeVideo> {
+    return this.fetch<YoutubeVideo>('/youtube/video', params);
+  }
+
+  /**
+   * Fetches YouTube channel information and videos.
+   *
+   * @param params - The parameters required to fetch the YouTube channel information.
+   * @param params.id - The YouTube channel ID.
+   * @returns A promise that resolves to a `YoutubeChannel` object containing the channel information.
+   *
+   * @property videos - Fetches the videos of the YouTube channel.
+   * @param params - The parameters required to fetch the YouTube channel videos.
+   * @param params.id - The YouTube channel ID.
+   * @param params.limit - The maximum number of videos to fetch.
+   *                       Default: 30. Max: 5000.
+   * @returns A promise that resolves to an array of video IDs.
+   *
+   * @throws {SupadataError} If the limit is invalid (less than 1 or greater than 5000).
+   */
+  channel = Object.assign(
+    async (params: ChannelParams): Promise<YoutubeChannel> => {
+      return this.fetch<YoutubeChannel>('/youtube/channel', params);
+    },
+    {
+      videos: async (params: ChannelVideosParams): Promise<string[]> => {
+        // Validate the limit locally to avoid unnecessary API calls.
+        this.validateLimit(params);
+        return this.fetch<string[]>('/youtube/channel/videos', params);
+      },
+    }
+  );
+
+  /**
+   * Fetches a YouTube playlist and its videos.
+   *
+   * @param params - The parameters required to fetch the playlist.
+   * @param params.id - The YouTube playlist ID.
+   * @returns A promise that resolves to a `YoutubePlaylist` object.
+   *
+   * @property videos - Fetches the videos of a YouTube playlist.
+   * @param params - The parameters required to fetch the playlist videos.
+   * @param params.id - The YouTube playlist ID.
+   * @param params.limit - The maximum number of videos to fetch.
+   *                       Default: 30. Max: 5000.
+   * @returns A promise that resolves to an array of video IDs.
+   *
+   * @throws {SupadataError} If the limit is invalid (less than 1 or greater than 5000).
+   */
+  playlist = Object.assign(
+    async (params: PlaylistParams): Promise<YoutubePlaylist> => {
+      return this.fetch<YoutubePlaylist>('/youtube/playlist', params);
+    },
+    {
+      videos: async (params: PlaylistVideosParams): Promise<string[]> => {
+        // Validate the limit locally to avoid unnecessary API calls.
+        this.validateLimit(params);
+        return this.fetch<string[]>('/youtube/playlist/videos', params);
+      },
+    }
+  );
+
+  private validateLimit(params: { limit?: number }) {
+    if (
+      params.limit != undefined &&
+      params.limit != null &&
+      (params.limit < 1 || params.limit > 5000)
+    ) {
+      throw new SupadataError({
+        error: 'invalid-request',
+        message: 'Invalid limit.',
+        details: 'The limit must be between 1 and 5000.',
+      });
+    }
   }
 }

--- a/src/services/youtube.ts
+++ b/src/services/youtube.ts
@@ -28,19 +28,15 @@ export interface TranslateParams extends Omit<TranscriptParams, 'lang'> {
   lang: string;
 }
 
-export interface VideoParams {
+export interface ResourceParams {
   id: string;
 }
 
-export interface ChannelParams extends VideoParams {}
-
-export interface ChannelVideosParams extends ChannelParams {
+export interface ChannelVideosParams extends ResourceParams {
   limit?: number;
 }
 
-export interface PlaylistParams extends VideoParams {}
-
-export interface PlaylistVideosParams extends PlaylistParams {
+export interface PlaylistVideosParams extends ResourceParams {
   limit?: number;
 }
 
@@ -83,7 +79,7 @@ export class YouTubeService extends BaseClient {
    * @param params.id - The YouTube video ID.
    * @returns A promise that resolves to a `YoutubeVideo` object.
    */
-  async video(params: VideoParams): Promise<YoutubeVideo> {
+  async video(params: ResourceParams): Promise<YoutubeVideo> {
     return this.fetch<YoutubeVideo>('/youtube/video', params);
   }
 
@@ -104,7 +100,7 @@ export class YouTubeService extends BaseClient {
    * @throws {SupadataError} If the limit is invalid (less than 1 or greater than 5000).
    */
   channel = Object.assign(
-    async (params: ChannelParams): Promise<YoutubeChannel> => {
+    async (params: ResourceParams): Promise<YoutubeChannel> => {
       return this.fetch<YoutubeChannel>('/youtube/channel', params);
     },
     {
@@ -133,7 +129,7 @@ export class YouTubeService extends BaseClient {
    * @throws {SupadataError} If the limit is invalid (less than 1 or greater than 5000).
    */
   playlist = Object.assign(
-    async (params: PlaylistParams): Promise<YoutubePlaylist> => {
+    async (params: ResourceParams): Promise<YoutubePlaylist> => {
       return this.fetch<YoutubePlaylist>('/youtube/playlist', params);
     },
     {

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,7 +26,7 @@ export interface Scrape {
   urls: string[];
 }
 
-export interface Map {
+export interface SiteMap {
   urls: string[];
 }
 
@@ -85,7 +85,7 @@ export interface YoutubeVideo {
   channel: {
     id: string;
     name: string;
-  }
+  };
   tags: string[];
   thumbnail: string;
   uploadDate: string;
@@ -97,7 +97,7 @@ export interface YoutubeVideo {
 export interface YoutubeChannel {
   id: string;
   name: string;
-  handle: string
+  handle: string;
   description: string;
   subscriberCount: number;
   videoCount: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -76,3 +76,41 @@ export class SupadataError extends Error {
     this.name = 'SupadataError';
   }
 }
+
+export interface YoutubeVideo {
+  id: string;
+  title: string;
+  description: string;
+  duration: number;
+  channel: {
+    id: string;
+    name: string;
+  }
+  tags: string[];
+  thumbnail: string;
+  uploadDate: string;
+  viewCount: number;
+  likeCount: number;
+  transcriptLanguages: string[];
+}
+
+export interface YoutubeChannel {
+  id: string;
+  name: string;
+  handle: string
+  description: string;
+  subscriberCount: number;
+  videoCount: number;
+  thumbnail: string;
+  banner: string;
+}
+
+export interface YoutubePlaylist {
+  id: string;
+  title: string;
+  videoCount: number;
+  viewCount: number;
+  lastUpdated: string;
+  description: string;
+  thumbnail: string;
+}


### PR DESCRIPTION
Fixes #4
/claim #4

**Requirements**

- [x] Support for above endpoints according to the documentation and aligned with patterns in this library is added
- [x] All parameters and returns are typed according to spec
- [x] README is updated
- [x] Test cases are added in [tests](https://github.com/supadata-ai/js/blob/main/src/__tests__/supadata.test.ts)
- [x] [/example](https://github.com/supadata-ai/js/tree/main/example) is updated

Implemented the support for all required endpoints, aligned with patterns in this library and the python one.  Implemented tests using the content from some real requests I made and all the tests are passing.

```
npm test 

> @supadata/js@1.0.4 test
> node --experimental-vm-modules node_modules/jest/bin/jest.js

(node:80852) ExperimentalWarning: VM Modules is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
(node:80852) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
 PASS  src/__tests__/supadata.test.ts
(node:80853) ExperimentalWarning: VM Modules is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
(node:80853) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
 PASS  src/__tests__/errors.test.ts

Test Suites: 2 passed, 2 total
Tests:       29 passed, 29 total
Snapshots:   0 total
Time:        2.754 s, estimated 4 s
Ran all test suites.
```

When installing the `devDependencies`, I also received some warnings due to old versions of packages in `package-lock.json`:

```
npm install

npm warn deprecated inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
```

So, I also updated the versions with `npm audit fix` to handle those warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced powerful capabilities to retrieve and display YouTube metadata, including detailed video, channel, and playlist information along with associated video lists.
- **Documentation**
	- Updated guides and examples to help users easily leverage the new YouTube data retrieval features.
- **Tests**
	- Expanded test coverage to ensure robust performance and proper error handling for all YouTube-related functionalities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->