### PR TITLE
Add /extract endpoint support to SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ npm install @supadata/js
 import {
   Crawl,
   CrawlJob,
+  ExtractJobResult,
+  JobId,
   JobResult,
   Map,
   Metadata,
@@ -81,6 +83,43 @@ if ('jobId' in transcriptResult) {
 } else {
   // For smaller files, we get the transcript directly
   console.log('Transcript:', transcriptResult);
+}
+```
+
+### Extract
+
+```typescript
+// Extract structured data from video content using AI
+// With a prompt (AI determines the schema)
+const job = await supadata.extract({
+  url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+  prompt: 'Extract the main topics and key takeaways',
+});
+console.log(`Started extract job: ${job.jobId}`);
+
+// With a JSON Schema (for structured output)
+const jobWithSchema = await supadata.extract({
+  url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+  schema: {
+    type: 'object',
+    properties: {
+      topics: { type: 'array', items: { type: 'string' } },
+      summary: { type: 'string' },
+    },
+    required: ['topics', 'summary'],
+  },
+});
+
+// Poll for results
+const result = await supadata.extract.getResults(job.jobId);
+if (result.status === 'completed') {
+  console.log('Extracted data:', result.data);
+  // If no schema was provided, the AI-generated schema is available:
+  console.log('Generated schema:', result.schema);
+} else if (result.status === 'failed') {
+  console.error('Extract failed:', result.error);
+} else {
+  console.log('Job status:', result.status); // 'queued' or 'active'
 }
 ```
 

--- a/example/index.ts
+++ b/example/index.ts
@@ -33,7 +33,46 @@ async function main() {
 
     await new Promise((resolve) => setTimeout(resolve, 2000));
 
-    // Example 3: Get transcript from any platform (YouTube, TikTok, Instagram, Twitter) or file
+    // Example 3: Extract structured data from video
+    console.log('\nℹ️ Extracting structured data from YouTube video...');
+    const extractJob = await supadata.extract({
+      url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+      prompt: 'Extract the main topics and key takeaways',
+    });
+    console.log(`ℹ️ Started extract job: ${extractJob.jobId}`);
+
+    // Poll for extract results
+    {
+      let attempts = 0;
+      const maxAttempts = 5;
+
+      while (attempts < maxAttempts) {
+        attempts++;
+        await new Promise((resolve) => setTimeout(resolve, 3000));
+
+        const extractResult = await supadata.extract.getResults(
+          extractJob.jobId
+        );
+        console.log(
+          `ℹ️ [Attempt ${attempts}] Extract job status: ${extractResult.status}`
+        );
+
+        if (extractResult.status === 'completed') {
+          console.log('ℹ️ Extracted data:', extractResult.data);
+          if (extractResult.schema) {
+            console.log('ℹ️ AI-generated schema:', extractResult.schema);
+          }
+          break;
+        } else if (extractResult.status === 'failed') {
+          console.error('🛑 Extract job failed:', extractResult.error);
+          break;
+        }
+      }
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+
+    // Example 4: Get transcript from any platform (YouTube, TikTok, Instagram, Twitter) or file
     console.log('\nℹ️ Getting transcript from YouTube...');
     const transcriptResult = await supadata.transcript({
       url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
@@ -75,7 +114,7 @@ async function main() {
 
     await new Promise((resolve) => setTimeout(resolve, 2000));
 
-    // Example 4: Get YouTube channel info
+    // Example 5: Get YouTube channel info
     console.log('\nℹ️ Getting YouTube channel info...');
     const channelInfo = await supadata.youtube.channel({
       id: 'https://www.youtube.com/@Fireship', // Fireship channel as an example
@@ -84,7 +123,7 @@ async function main() {
 
     await new Promise((resolve) => setTimeout(resolve, 2000));
 
-    // Example 5: Get YouTube channel videos
+    // Example 6: Get YouTube channel videos
     console.log('\nℹ️ Getting YouTube channel videos...');
     const channelVideos = await supadata.youtube.channel.videos({
       id: 'https://www.youtube.com/@Fireship', // Fireship channel as an example
@@ -93,7 +132,7 @@ async function main() {
 
     await new Promise((resolve) => setTimeout(resolve, 2000));
 
-    // Example 6: Get YouTube playlist info
+    // Example 7: Get YouTube playlist info
     console.log('\nℹ️ Getting YouTube playlist info...');
     const playlistInfo = await supadata.youtube.playlist({
       id: 'PL0vfts4VzfNjnYhJMfTulea5McZbQLM7G', // Fireship playlist as an example
@@ -102,7 +141,7 @@ async function main() {
 
     await new Promise((resolve) => setTimeout(resolve, 2000));
 
-    // Example 7: Get YouTube playlist videos
+    // Example 8: Get YouTube playlist videos
     console.log('\nℹ️ Getting YouTube playlist videos...');
     const playlistVideos = await supadata.youtube.playlist.videos({
       id: 'PL0vfts4VzfNjnYhJMfTulea5McZbQLM7G', // Fireship playlist as an example
@@ -111,7 +150,7 @@ async function main() {
 
     await new Promise((resolve) => setTimeout(resolve, 2000));
 
-    // Example 8: Search YouTube videos
+    // Example 9: Search YouTube videos
     console.log('\nℹ️ Searching YouTube videos...');
     const searchResults = await supadata.youtube.search({
       query: 'rick astley never gonna give you up',
@@ -123,7 +162,7 @@ async function main() {
 
     await new Promise((resolve) => setTimeout(resolve, 2000));
 
-    // Example 9: Search YouTube with filters
+    // Example 10: Search YouTube with filters
     console.log('\nℹ️ Searching YouTube with filters...');
     const filteredSearch = await supadata.youtube.search({
       query: 'javascript tutorial',
@@ -137,7 +176,7 @@ async function main() {
 
     await new Promise((resolve) => setTimeout(resolve, 2000));
 
-    // Example 10: Search YouTube channels
+    // Example 11: Search YouTube channels
     console.log('\nℹ️ Searching YouTube channels...');
     const channelSearch = await supadata.youtube.search({
       query: 'fireship',
@@ -148,21 +187,21 @@ async function main() {
 
     await new Promise((resolve) => setTimeout(resolve, 2000));
 
-    // Example 11: Scrape web content
+    // Example 12: Scrape web content
     console.log('\nℹ️ Scraping web content...');
     const webContent = await supadata.web.scrape('https://supadata.ai');
     console.log('ℹ️ Web content:', webContent);
 
     await new Promise((resolve) => setTimeout(resolve, 2000));
 
-    // Example 12: Map website URLs
+    // Example 13: Map website URLs
     console.log('\nℹ️ Mapping website URLs...');
     const siteMap = await supadata.web.map('https://supadata.ai');
     console.log('ℹ️ Site map:', siteMap);
 
     await new Promise((resolve) => setTimeout(resolve, 2000));
 
-    // Example 13: Crawl website with limit
+    // Example 14: Crawl website with limit
     console.log('\nℹ️ Crawling website...');
     const crawl = await supadata.web.crawl({
       url: 'https://supadata.ai',
@@ -172,14 +211,14 @@ async function main() {
 
     await new Promise((resolve) => setTimeout(resolve, 5000));
 
-    // Example 14: Get crawl results
+    // Example 15: Get crawl results
     console.log('\nℹ️ Getting crawl results...');
     const crawlResults = await supadata.web.getCrawlResults(crawl.jobId);
     console.log('ℹ️ Crawl results:', crawlResults);
 
     await new Promise((resolve) => setTimeout(resolve, 2000));
 
-    // Example 15: Start YouTube transcript batch job
+    // Example 16: Start YouTube transcript batch job
     console.log('\nℹ️ Starting YouTube transcript batch job...');
     const transcriptBatchJob: YoutubeBatchJob =
       await supadata.youtube.transcript.batch({
@@ -190,7 +229,7 @@ async function main() {
 
     await new Promise((resolve) => setTimeout(resolve, 2000));
 
-    // Example 16: Start YouTube video metadata batch job
+    // Example 17: Start YouTube video metadata batch job
     console.log('\nℹ️ Starting YouTube video metadata batch job...');
     const videoBatchJob: YoutubeBatchJob = await supadata.youtube.video.batch({
       playlistId: 'PLlaN88a7y2_plecYoJxvRFTLHVbIVAOoc', // Example playlist
@@ -200,7 +239,7 @@ async function main() {
 
     await new Promise((resolve) => setTimeout(resolve, 2000));
 
-    // Example 17: Poll and get batch results (using transcript job ID from Example 15)
+    // Example 18: Poll and get batch results (using transcript job ID from Example 16)
     console.log(
       `\nℹ️ Polling for batch results for job: ${transcriptBatchJob.jobId}...`
     );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@supadata/js",
-  "version": "1.2.1",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@supadata/js",
-      "version": "1.2.1",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "cross-fetch": "^4.0.0"
@@ -66,6 +66,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.7.tgz",
       "integrity": "sha512-SRijHmF0PSPgLIBYlWnG0hyeJLwXE2CgpsXaMOrtt2yp9/86ALw6oUlj9KYuZ0JN07T4eBMVIW4li/9S1j2BGA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
@@ -2027,6 +2028,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -2437,6 +2439,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -3018,6 +3021,7 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -4728,6 +4732,7 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4956,6 +4961,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
       "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@supadata/js",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "description": "TypeScript / JavaScript SDK for Supadata API",
   "homepage": "https://supadata.ai",
   "repository": "https://github.com/supadata-ai/js",

--- a/src/__tests__/supadata.test.ts
+++ b/src/__tests__/supadata.test.ts
@@ -2,6 +2,7 @@ import fetchMock from 'jest-fetch-mock';
 import { Supadata } from '../index.js';
 import type {
   CrawlJob,
+  ExtractJobResult,
   JobId,
   JobResult,
   Metadata,
@@ -1207,6 +1208,233 @@ describe('Supadata SDK', () => {
           url: 'https://www.youtube.com/watch?v=INVALID',
         })
       ).rejects.toThrow('The requested item could not be found');
+    });
+  });
+
+  describe('Extract Service', () => {
+    it('should start extract job with prompt', async () => {
+      const mockResponse: JobId = {
+        jobId: '123e4567-e89b-12d3-a456-426614174000',
+      };
+
+      fetchMock.mockResponseOnce(JSON.stringify(mockResponse), {
+        headers: { 'content-type': 'application/json' },
+      });
+
+      const result = await supadata.extract({
+        url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+        prompt: 'Extract the main topics and key takeaways',
+      });
+
+      expect(result).toEqual(mockResponse);
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://api.supadata.ai/v1/extract',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            'x-api-key': 'test-api-key',
+            'Content-Type': 'application/json',
+            'User-Agent': expect.stringContaining('supadata-js'),
+          }),
+          body: JSON.stringify({
+            url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+            prompt: 'Extract the main topics and key takeaways',
+          }),
+        })
+      );
+    });
+
+    it('should start extract job with schema', async () => {
+      const mockResponse: JobId = {
+        jobId: '123e4567-e89b-12d3-a456-426614174001',
+      };
+      const schema = {
+        type: 'object',
+        properties: {
+          topics: { type: 'array', items: { type: 'string' } },
+          summary: { type: 'string' },
+        },
+        required: ['topics', 'summary'],
+      };
+
+      fetchMock.mockResponseOnce(JSON.stringify(mockResponse), {
+        headers: { 'content-type': 'application/json' },
+      });
+
+      const result = await supadata.extract({
+        url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+        schema,
+      });
+
+      expect(result).toEqual(mockResponse);
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://api.supadata.ai/v1/extract',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+            schema,
+          }),
+        })
+      );
+    });
+
+    it('should start extract job with prompt and schema', async () => {
+      const mockResponse: JobId = {
+        jobId: '123e4567-e89b-12d3-a456-426614174002',
+      };
+      const schema = {
+        type: 'object',
+        properties: {
+          topics: { type: 'array', items: { type: 'string' } },
+        },
+      };
+
+      fetchMock.mockResponseOnce(JSON.stringify(mockResponse), {
+        headers: { 'content-type': 'application/json' },
+      });
+
+      const result = await supadata.extract({
+        url: 'https://www.tiktok.com/@user/video/1234567890',
+        prompt: 'Extract the main topics',
+        schema,
+      });
+
+      expect(result).toEqual(mockResponse);
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://api.supadata.ai/v1/extract',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            url: 'https://www.tiktok.com/@user/video/1234567890',
+            prompt: 'Extract the main topics',
+            schema,
+          }),
+        })
+      );
+    });
+
+    it('should get extract results when job is completed', async () => {
+      const jobId = '123e4567-e89b-12d3-a456-426614174000';
+      const mockResponse: ExtractJobResult = {
+        status: 'completed',
+        error: null,
+        data: {
+          topics: ['AI basics', 'Machine learning'],
+          summary: 'An introduction to artificial intelligence',
+        },
+      };
+
+      fetchMock.mockResponseOnce(JSON.stringify(mockResponse), {
+        headers: { 'content-type': 'application/json' },
+      });
+
+      const result = await supadata.extract.getResults(jobId);
+
+      expect(result).toEqual(mockResponse);
+      expect(fetchMock).toHaveBeenCalledWith(
+        `https://api.supadata.ai/v1/extract/${jobId}`,
+        expect.objectContaining({
+          method: 'GET',
+          headers: expect.objectContaining({
+            'x-api-key': 'test-api-key',
+            'Content-Type': 'application/json',
+            'User-Agent': expect.stringContaining('supadata-js'),
+          }),
+        })
+      );
+    });
+
+    it('should get extract results with AI-generated schema', async () => {
+      const jobId = '123e4567-e89b-12d3-a456-426614174003';
+      const mockResponse: ExtractJobResult = {
+        status: 'completed',
+        error: null,
+        data: {
+          topics: ['Neural networks'],
+          summary: 'Deep learning overview',
+        },
+        schema: {
+          type: 'object',
+          properties: {
+            topics: { type: 'array', items: { type: 'string' } },
+            summary: { type: 'string' },
+          },
+          required: ['topics', 'summary'],
+        },
+      };
+
+      fetchMock.mockResponseOnce(JSON.stringify(mockResponse), {
+        headers: { 'content-type': 'application/json' },
+      });
+
+      const result = await supadata.extract.getResults(jobId);
+
+      expect(result).toEqual(mockResponse);
+      expect(result.schema).toBeDefined();
+      expect(result.data).toBeDefined();
+    });
+
+    it('should get extract results when job is still active', async () => {
+      const jobId = '123e4567-e89b-12d3-a456-426614174004';
+      const mockResponse: ExtractJobResult = {
+        status: 'active',
+      };
+
+      fetchMock.mockResponseOnce(JSON.stringify(mockResponse), {
+        headers: { 'content-type': 'application/json' },
+      });
+
+      const result = await supadata.extract.getResults(jobId);
+
+      expect(result).toEqual(mockResponse);
+      expect(result.status).toBe('active');
+    });
+
+    it('should get extract results when job failed', async () => {
+      const jobId = '123e4567-e89b-12d3-a456-426614174005';
+      const mockResponse: ExtractJobResult = {
+        status: 'failed',
+        error: {
+          error: 'internal-error',
+          message: 'Extract failed',
+          details: 'Failed to process the video',
+        },
+      };
+
+      fetchMock.mockResponseOnce(JSON.stringify(mockResponse), {
+        headers: { 'content-type': 'application/json' },
+      });
+
+      const result = await supadata.extract.getResults(jobId);
+
+      expect(result).toEqual(mockResponse);
+      expect(result.status).toBe('failed');
+      expect(result.error).toBeDefined();
+    });
+
+    it('should throw error when getting results with no jobId', async () => {
+      await expect(supadata.extract.getResults('')).rejects.toThrow(
+        'Missing jobId'
+      );
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('should handle API errors', async () => {
+      const mockResponse = {
+        error: 'not-found',
+        message: 'Job not found',
+        details: 'The specified job could not be found',
+      };
+
+      fetchMock.mockResponseOnce(JSON.stringify(mockResponse), {
+        status: 404,
+        headers: { 'content-type': 'application/json' },
+      });
+
+      await expect(
+        supadata.extract.getResults('invalid-job-id')
+      ).rejects.toThrow('Job not found');
     });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,7 @@
 import {
+  ExtractJobResult,
+  ExtractParams,
+  JobId,
   JobResult,
   Metadata,
   SupadataConfig,
@@ -11,6 +14,7 @@ import {
   TranscriptService,
   GeneralTranscriptParams,
 } from './services/transcript.js';
+import { ExtractService } from './services/extract.js';
 import { BaseClient } from './client.js';
 
 export * from './types.js';
@@ -21,6 +25,7 @@ export {
   TranscriptService,
   GeneralTranscriptParams,
 } from './services/transcript.js';
+export { ExtractService } from './services/extract.js';
 
 export interface MetadataParams {
   url: string;
@@ -30,12 +35,14 @@ export class Supadata extends BaseClient {
   readonly youtube: YouTubeService;
   readonly web: WebService;
   private _transcriptService: TranscriptService;
+  private _extractService: ExtractService;
 
   constructor(config: SupadataConfig) {
     super(config);
     this.youtube = new YouTubeService(config);
     this.web = new WebService(config);
     this._transcriptService = new TranscriptService(config);
+    this._extractService = new ExtractService(config);
   }
 
   /**
@@ -62,4 +69,20 @@ export class Supadata extends BaseClient {
   metadata = async (params: MetadataParams): Promise<Metadata> => {
     return this.fetch<Metadata>('/metadata', params);
   };
+
+  /**
+   * Extract structured data from video content using AI.
+   * Returns a job ID for asynchronous processing.
+   * Use extract.getResults(jobId) to poll for results.
+   */
+  extract = Object.assign(
+    async (params: ExtractParams): Promise<JobId> => {
+      return this._extractService.get(params);
+    },
+    {
+      getResults: (jobId: string): Promise<ExtractJobResult> => {
+        return this._extractService.getResults(jobId);
+      },
+    }
+  );
 }

--- a/src/services/extract.ts
+++ b/src/services/extract.ts
@@ -1,0 +1,36 @@
+import { BaseClient } from '../client.js';
+import {
+  ExtractJobResult,
+  ExtractParams,
+  JobId,
+  SupadataError,
+} from '../types.js';
+
+export class ExtractService extends BaseClient {
+  /**
+   * Start an extract job to analyze video content and extract structured data.
+   * @param params - Parameters for the extract job
+   * @returns A promise that resolves to a JobId for async processing
+   */
+  get = async (params: ExtractParams): Promise<JobId> => {
+    return this.fetch<JobId>('/extract', params, 'POST');
+  };
+
+  /**
+   * Get results for an extract job by job ID.
+   * @param jobId - The ID of the extract job
+   * @returns A promise that resolves to the extract job result
+   * @throws {SupadataError} If jobId is not provided
+   */
+  getResults = async (jobId: string): Promise<ExtractJobResult> => {
+    if (!jobId) {
+      throw new SupadataError({
+        error: 'invalid-request',
+        message: 'Missing jobId',
+        details:
+          'The jobId parameter is required to get extract job results.',
+      });
+    }
+    return this.fetch<ExtractJobResult>(`/extract/${jobId}`);
+  };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -306,3 +306,22 @@ export interface Metadata {
   createdAt: string;
   additionalData: Record<string, any>;
 }
+
+// Extract Types
+export interface ExtractParams {
+  url: string;
+  prompt?: string;
+  schema?: Record<string, any>;
+}
+
+export interface ExtractJobResult {
+  status: JobStatus;
+  error?: {
+    error: SupadataError['error'];
+    message: string;
+    details: string;
+    documentationUrl?: string;
+  } | null;
+  data?: Record<string, any>;
+  schema?: Record<string, any>;
+}


### PR DESCRIPTION
## Summary
- Add new `/extract` endpoint for AI-powered structured data extraction from videos
- Support both prompt-based and schema-based extraction with optional AI schema generation
- Async job pattern matching existing transcript service (POST to start, GET to poll)
- Version bumped to 1.4.0

## Changes
- New `ExtractService` class with `get()` and `getResults()` methods
- `ExtractParams` and `ExtractJobResult` type definitions
- Comprehensive test coverage (8 tests for extract scenarios)
- README section with usage examples (prompt, schema, polling)
- Example usage in project examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)